### PR TITLE
Fix error with Bulk Catalog Item jobs

### DIFF
--- a/KlaviyoSharp/Models/CatalogItemBulkJob.cs
+++ b/KlaviyoSharp/Models/CatalogItemBulkJob.cs
@@ -96,5 +96,5 @@ public class CatalogItemBulkJobAttributes
     /// <summary>
     /// Array of catalog items to create.
     /// </summary>
-    public List<CatalogItem> Items { get; set; }
+    public DataListObject<CatalogItem> Items { get; set; }
 }


### PR DESCRIPTION
The Items field in CatalogBulkItemAttributes should be a DataListObject rather than a List so the JSON renders properly. 