### PR TITLE
Put -> Patch: Addressed issue https://github.com/zac-schutt/KlaviyoSharp/issues/25

### DIFF
--- a/KlaviyoSharp/KlaviyoSharp.csproj
+++ b/KlaviyoSharp/KlaviyoSharp.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <AssemblyName>KlaviyoSharp</AssemblyName>
     <RootNamespace>KlaviyoSharp</RootNamespace>
-    <VersionPrefix>1.2.1</VersionPrefix>
+    <VersionPrefix>1.2.2</VersionPrefix>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/KlaviyoSharp/KlaviyoSharp.csproj
+++ b/KlaviyoSharp/KlaviyoSharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <AssemblyName>KlaviyoSharp</AssemblyName>
     <RootNamespace>KlaviyoSharp</RootNamespace>
     <VersionPrefix>1.2.2</VersionPrefix>

--- a/KlaviyoSharp/Services/CatalogServices.cs
+++ b/KlaviyoSharp/Services/CatalogServices.cs
@@ -62,7 +62,7 @@ public class CatalogServices : KlaviyoServiceBase, ICatalogServices
                                                                  CatalogItem catalogItem,
                                                                  CancellationToken cancellationToken = default)
     {
-        return await _klaviyoService.HTTP<DataObject<CatalogItem>>(HttpMethod.Put, $"catalog-items/{catalogItemId}/",
+        return await _klaviyoService.HTTP<DataObject<CatalogItem>>(HttpMethod.Patch, $"catalog-items/{catalogItemId}/",
                                                                    _revision, null, null,
                                                                    new DataObject<CatalogItem>(catalogItem),
                                                                    cancellationToken);
@@ -242,7 +242,7 @@ public class CatalogServices : KlaviyoServiceBase, ICatalogServices
                                                                        CatalogVariant catalogVariant,
                                                                        CancellationToken cancellationToken = default)
     {
-        return await _klaviyoService.HTTP<DataObject<CatalogVariant>>(HttpMethod.Put,
+        return await _klaviyoService.HTTP<DataObject<CatalogVariant>>(HttpMethod.Patch,
                                                                       $"catalog-variants/{catalogVariantId}/", _revision,
                                                                       null, null,
                                                                       new DataObject<CatalogVariant>(catalogVariant),
@@ -434,7 +434,7 @@ public class CatalogServices : KlaviyoServiceBase, ICatalogServices
                                                                          CatalogCategory catalogCategory,
                                                                          CancellationToken cancellationToken = default)
     {
-        return await _klaviyoService.HTTP<DataObject<CatalogCategory>>(HttpMethod.Put,
+        return await _klaviyoService.HTTP<DataObject<CatalogCategory>>(HttpMethod.Patch,
                                                                        $"catalog-categories/{catalogCategoryId}/",
                                                                        _revision, null, null,
                                                                        new DataObject<CatalogCategory>(catalogCategory),

--- a/KlaviyoSharp/Services/CatalogServices.cs
+++ b/KlaviyoSharp/Services/CatalogServices.cs
@@ -62,7 +62,7 @@ public class CatalogServices : KlaviyoServiceBase, ICatalogServices
                                                                  CatalogItem catalogItem,
                                                                  CancellationToken cancellationToken = default)
     {
-        return await _klaviyoService.HTTP<DataObject<CatalogItem>>(HttpMethod.Patch, $"catalog-items/{catalogItemId}/",
+        return await _klaviyoService.HTTP<DataObject<CatalogItem>>(new HttpMethod("PATCH"), $"catalog-items/{catalogItemId}/",
                                                                    _revision, null, null,
                                                                    new DataObject<CatalogItem>(catalogItem),
                                                                    cancellationToken);
@@ -242,7 +242,7 @@ public class CatalogServices : KlaviyoServiceBase, ICatalogServices
                                                                        CatalogVariant catalogVariant,
                                                                        CancellationToken cancellationToken = default)
     {
-        return await _klaviyoService.HTTP<DataObject<CatalogVariant>>(HttpMethod.Patch,
+        return await _klaviyoService.HTTP<DataObject<CatalogVariant>>(new HttpMethod("PATCH"),
                                                                       $"catalog-variants/{catalogVariantId}/", _revision,
                                                                       null, null,
                                                                       new DataObject<CatalogVariant>(catalogVariant),
@@ -434,7 +434,7 @@ public class CatalogServices : KlaviyoServiceBase, ICatalogServices
                                                                          CatalogCategory catalogCategory,
                                                                          CancellationToken cancellationToken = default)
     {
-        return await _klaviyoService.HTTP<DataObject<CatalogCategory>>(HttpMethod.Patch,
+        return await _klaviyoService.HTTP<DataObject<CatalogCategory>>(new HttpMethod("PATCH"),
                                                                        $"catalog-categories/{catalogCategoryId}/",
                                                                        _revision, null, null,
                                                                        new DataObject<CatalogCategory>(catalogCategory),


### PR DESCRIPTION
Addressed issue https://github.com/zac-schutt/KlaviyoSharp/issues/25

UpdateCatalogItem / UpdateCatalogVariant / UpdateCatalogCategory use HttpMethod.Put internally, whilst the API only accepts HttpMethod.Patch (Fails with a 'method not allowed' error).

Additionally, netstandard 2.0 doesn't support 'Patch' as an option - so, need to update to 2.1